### PR TITLE
Update typography.css

### DIFF
--- a/MyApp/wwwroot/css/typography.css
+++ b/MyApp/wwwroot/css/typography.css
@@ -1,240 +1,778 @@
 /* @tailwindcss/typography */
-.prose {color: inherit;max-width: 65ch }.prose :where([class~="lead"]):not(:where([class~="not-prose"] *)) {color: var(--tw-prose-lead);font-size: 1.25em;line-height: 1.6;margin-top: 1.2em;margin-bottom: 1.2em }.prose :where(a):not(:where([class~="not-prose"] *)) {color: inherit;text-decoration: underline;font-weight: 500 }.prose :where(a):not(:where([class~="not-prose"] *)):hover {opacity: .8;color: #4b5563 }.prose :where(strong):not(:where([class~="not-prose"] *)) {color: inherit;font-weight: 600 }.prose :where(ol):not(:where([class~="not-prose"] *)) {list-style-type: decimal;padding-left: 1.625em }.prose :where(ol[type="A"]):not(:where([class~="not-prose"] *)) {list-style-type: upper-alpha }.prose :where(ol[type="a"]):not(:where([class~="not-prose"] *)) {list-style-type: lower-alpha }.prose :where(ol[type="A"]):not(:where([class~="not-prose"] *)) {list-style-type: upper-alpha }.prose :where(ol[type="a"]):not(:where([class~="not-prose"] *)) {list-style-type: lower-alpha }.prose :where(ol[type="I"]):not(:where([class~="not-prose"] *)) {list-style-type: upper-roman }.prose :where(ol[type="i"]):not(:where([class~="not-prose"] *)) {list-style-type: lower-roman }.prose :where(ol[type="I"]):not(:where([class~="not-prose"] *)) {list-style-type: upper-roman }.prose :where(ol[type="i"]):not(:where([class~="not-prose"] *)) {list-style-type: lower-roman }.prose :where(ol[type="1"]):not(:where([class~="not-prose"] *)) {list-style-type: decimal }.prose :where(ul):not(:where([class~="not-prose"] *)) {list-style-type: disc;padding-left: 1.625em }.prose :where(ol > li):not(:where([class~="not-prose"] *))::marker {font-weight: 400;color: var(--tw-prose-counters) }.prose :where(ul > li):not(:where([class~="not-prose"] *))::marker {color: var(--tw-prose-bullets) }.prose :where(hr):not(:where([class~="not-prose"] *)) {border-color: var(--tw-prose-hr);border-top-width: 1px;margin-top: 3em;margin-bottom: 3em }.prose :where(blockquote):not(:where([class~="not-prose"] *)) {font-weight: 500;font-style: italic;color: var(--tw-prose-quotes);border-left-width: .25rem;border-left-color: var(--tw-prose-quote-borders);quotes: "\201c""\201d""\2018""\2019";margin-top: 1.6em;margin-bottom: 1.6em;padding-left: 1em }.prose :where(blockquote p:first-of-type):not(:where([class~="not-prose"] *)):before {content: open-quote }.prose :where(blockquote p:last-of-type):not(:where([class~="not-prose"] *)):after {content: close-quote }.prose :where(h1):not(:where([class~="not-prose"] *)) {color: inherit;font-weight: 800;font-size: 2.25em;margin-top: 0;margin-bottom: .8888889em;line-height: 1.1111111 }.prose :where(h1 strong):not(:where([class~="not-prose"] *)) {font-weight: 900 }.prose :where(h2):not(:where([class~="not-prose"] *)) {color: inherit;font-weight: 700;font-size: 1.5em;margin-top: 2em;margin-bottom: 1em;line-height: 1.3333333 }.prose :where(h2 strong):not(:where([class~="not-prose"] *)) {font-weight: 800 }.prose :where(h3):not(:where([class~="not-prose"] *)) {color: inherit;font-weight: 600;font-size: 1.25em;margin-top: 1.6em;margin-bottom: .6em;line-height: 1.6 }.prose :where(h3 strong):not(:where([class~="not-prose"] *)) {font-weight: 700 }.prose :where(h4):not(:where([class~="not-prose"] *)) {color: inherit;font-weight: 600;margin-top: 1.5em;margin-bottom: .5em;line-height: 1.5 }.prose :where(h4 strong):not(:where([class~="not-prose"] *)) {font-weight: 700 }.prose :where(figure > *):not(:where([class~="not-prose"] *)) {margin-top: 0;margin-bottom: 0 }.prose :where(figcaption):not(:where([class~="not-prose"] *)) {color: var(--tw-prose-captions);font-size: .875em;line-height: 1.4285714;margin-top: .8571429em }.prose :where(code):not(:where([class~="not-prose"] *)) {color: #3b82f6;font-weight: 400;font-size: .875em;background-color: #eff6ff;border-radius: .25rem;padding: .25em .5rem }.prose :where(code):not(:where([class~="not-prose"] *)):before {content: "" }.prose :where(code):not(:where([class~="not-prose"] *)):after {content: "" }.prose :where(a code):not(:where([class~="not-prose"] *)) {color: var(--tw-prose-links) }.prose :where(pre):not(:where([class~="not-prose"] *)) {color: var(--tw-prose-pre-code);background-color: var(--tw-prose-pre-bg);overflow-x: auto;font-weight: 400;font-size: .875em;line-height: 1.7142857;margin-top: 1.7142857em;margin-bottom: 1.7142857em;border-radius: .375rem;padding: .8571429em 1.1428571em;max-width: calc(100vw - 1rem) }.prose :where(pre code):not(:where([class~="not-prose"] *)) {background-color: transparent;border-width: 0;border-radius: 0;padding: 0;font-weight: inherit;color: inherit;font-size: inherit;font-family: inherit;line-height: inherit }.prose :where(pre code):not(:where([class~="not-prose"] *)):before {content: none }.prose :where(pre code):not(:where([class~="not-prose"] *)):after {content: none }.prose :where(table):not(:where([class~="not-prose"] *)) {width: 100%;table-layout: auto;text-align: left;margin-top: 2em;margin-bottom: 2em;font-size: .875em;line-height: 1.7142857 }.prose :where(thead):not(:where([class~="not-prose"] *)) {border-bottom-width: 1px;border-bottom-color: var(--tw-prose-th-borders) }.prose :where(thead th):not(:where([class~="not-prose"] *)) {color: var(--tw-prose-headings);font-weight: 600;vertical-align: bottom;padding-right: .5714286em;padding-bottom: .5714286em;padding-left: .5714286em }.prose :where(tbody tr):not(:where([class~="not-prose"] *)) {border-bottom-width: 1px;border-bottom-color: var(--tw-prose-td-borders) }.prose :where(tbody tr:last-child):not(:where([class~="not-prose"] *)) {border-bottom-width: 0 }.prose :where(tbody td):not(:where([class~="not-prose"] *)) {vertical-align: baseline;padding: .5714286em }.prose {--tw-prose-body: #374151;--tw-prose-headings: #111827;--tw-prose-lead: #4b5563;--tw-prose-links: #111827;--tw-prose-bold: #111827;--tw-prose-counters: #6b7280;--tw-prose-bullets: #d1d5db;--tw-prose-hr: #e5e7eb;--tw-prose-quotes: #111827;--tw-prose-quote-borders: #e5e7eb;--tw-prose-captions: #6b7280;--tw-prose-code: #111827;--tw-prose-pre-code: #e5e7eb;--tw-prose-pre-bg: #1f2937;--tw-prose-th-borders: #d1d5db;--tw-prose-td-borders: #e5e7eb;--tw-prose-invert-body: #d1d5db;--tw-prose-invert-headings: #fff;--tw-prose-invert-lead: #9ca3af;--tw-prose-invert-links: #fff;--tw-prose-invert-bold: #fff;--tw-prose-invert-counters: #9ca3af;--tw-prose-invert-bullets: #4b5563;--tw-prose-invert-hr: #374151;--tw-prose-invert-quotes: #f3f4f6;--tw-prose-invert-quote-borders: #374151;--tw-prose-invert-captions: #9ca3af;--tw-prose-invert-code: #fff;--tw-prose-invert-pre-code: #d1d5db;--tw-prose-invert-pre-bg: rgb(0 0 0 / 50%);--tw-prose-invert-th-borders: #4b5563;--tw-prose-invert-td-borders: #374151;font-size: 1rem;line-height: 1.75 }.prose :where(p):not(:where([class~="not-prose"] *)) {margin-top: 1.25em;margin-bottom: 1.25em }.prose :where(img):not(:where([class~="not-prose"] *)) {margin-top: 2em;margin-bottom: 2em }.prose :where(video):not(:where([class~="not-prose"] *)) {margin-top: 2em;margin-bottom: 2em }.prose :where(figure):not(:where([class~="not-prose"] *)) {margin-top: 2em;margin-bottom: 2em }.prose :where(h2 code):not(:where([class~="not-prose"] *)) {font-size: .875em }.prose :where(h3 code):not(:where([class~="not-prose"] *)) {font-size: .9em }.prose :where(li):not(:where([class~="not-prose"] *)) {margin-top: .5em;margin-bottom: .5em }.prose :where(ol > li):not(:where([class~="not-prose"] *)) {padding-left: .375em }.prose :where(ul > li):not(:where([class~="not-prose"] *)) {padding-left: .375em }.prose>:where(ul > li p):not(:where([class~="not-prose"] *)) {margin-top: .75em;margin-bottom: .75em }.prose>:where(ul > li > *:first-child):not(:where([class~="not-prose"] *)) {margin-top: 1.25em }.prose>:where(ul > li > *:last-child):not(:where([class~="not-prose"] *)) {margin-bottom: 1.25em }.prose>:where(ol > li > *:first-child):not(:where([class~="not-prose"] *)) {margin-top: 1.25em }.prose>:where(ol > li > *:last-child):not(:where([class~="not-prose"] *)) {margin-bottom: 1.25em }.prose :where(ul ul,ul ol,ol ul,ol ol):not(:where([class~="not-prose"] *)) {margin-top: .75em;margin-bottom: .75em }.prose :where(hr + *):not(:where([class~="not-prose"] *)) {margin-top: 0 }.prose :where(h2 + *):not(:where([class~="not-prose"] *)) {margin-top: 0 }.prose :where(h3 + *):not(:where([class~="not-prose"] *)) {margin-top: 0 }.prose :where(h4 + *):not(:where([class~="not-prose"] *)) {margin-top: 0 }.prose :where(thead th:first-child):not(:where([class~="not-prose"] *)) {padding-left: 0 }.prose :where(thead th:last-child):not(:where([class~="not-prose"] *)) {padding-right: 0 }.prose :where(tbody td:first-child):not(:where([class~="not-prose"] *)) {padding-left: 0 }.prose :where(tbody td:last-child):not(:where([class~="not-prose"] *)) {padding-right: 0 }.prose>:where(:first-child):not(:where([class~="not-prose"] *)) {margin-top: 0 }.prose>:where(:last-child):not(:where([class~="not-prose"] *)) {margin-bottom: 0 }.prose :where(b):not(:where([class~="not-prose"] *)) {color: inherit }.prose :where(em):not(:where([class~="not-prose"] *)) {color: inherit }
+.prose {
+	color: inherit;
+	/*max-width: 65ch;*/
+}
+
+.prose :where([class~="lead"]):not(:where([class~="not-prose"] *)) {
+	color: var(--tw-prose-lead);
+	font-size: 1.25em;
+	line-height: 1.6;
+	margin-top: 1.2em;
+	margin-bottom: 1.2em
+}
+
+.prose :where(a):not(:where([class~="not-prose"] *)) {
+	color: inherit;
+	text-decoration: underline;
+	font-weight: 500
+}
+
+.prose :where(a):not(:where([class~="not-prose"] *)):hover {
+	opacity: .8;
+	color: #4b5563
+}
+
+.prose :where(strong):not(:where([class~="not-prose"] *)) {
+	color: inherit;
+	font-weight: 600
+}
+
+.prose :where(ol):not(:where([class~="not-prose"] *)) {
+	list-style-type: decimal;
+	padding-left: 1.625em
+}
+
+.prose :where(ol[type="A"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: upper-alpha
+}
+
+.prose :where(ol[type="a"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: lower-alpha
+}
+
+.prose :where(ol[type="A"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: upper-alpha
+}
+
+.prose :where(ol[type="a"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: lower-alpha
+}
+
+.prose :where(ol[type="I"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: upper-roman
+}
+
+.prose :where(ol[type="i"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: lower-roman
+}
+
+.prose :where(ol[type="I"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: upper-roman
+}
+
+.prose :where(ol[type="i"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: lower-roman
+}
+
+.prose :where(ol[type="1"]):not(:where([class~="not-prose"] *)) {
+	list-style-type: decimal
+}
+
+.prose :where(ul):not(:where([class~="not-prose"] *)) {
+	list-style-type: disc;
+	padding-left: 1.625em
+}
+
+.prose :where(ol > li):not(:where([class~="not-prose"] *))::marker {
+	font-weight: 400;
+	color: var(--tw-prose-counters)
+}
+
+.prose :where(ul > li):not(:where([class~="not-prose"] *))::marker {
+	color: var(--tw-prose-bullets)
+}
+
+.prose :where(hr):not(:where([class~="not-prose"] *)) {
+	border-color: var(--tw-prose-hr);
+	border-top-width: 1px;
+	margin-top: 3em;
+	margin-bottom: 3em
+}
+
+.prose :where(blockquote):not(:where([class~="not-prose"] *)) {
+	font-weight: 500;
+	font-style: italic;
+	color: var(--tw-prose-quotes);
+	border-left-width: .25rem;
+	border-left-color: var(--tw-prose-quote-borders);
+	quotes: "\201c""\201d""\2018""\2019";
+	margin-top: 1.6em;
+	margin-bottom: 1.6em;
+	padding-left: 1em
+}
+
+.prose :where(blockquote p:first-of-type):not(:where([class~="not-prose"] *)):before {
+	content: open-quote
+}
+
+.prose :where(blockquote p:last-of-type):not(:where([class~="not-prose"] *)):after {
+	content: close-quote
+}
+
+.prose :where(h1):not(:where([class~="not-prose"] *)) {
+	color: inherit;
+	font-weight: 800;
+	font-size: 2.25em;
+	margin-top: 0;
+	margin-bottom: .8888889em;
+	line-height: 1.1111111
+}
+
+.prose :where(h1 strong):not(:where([class~="not-prose"] *)) {
+	font-weight: 900
+}
+
+.prose :where(h2):not(:where([class~="not-prose"] *)) {
+	color: inherit;
+	font-weight: 700;
+	font-size: 1.5em;
+	margin-top: 2em;
+	margin-bottom: 1em;
+	line-height: 1.3333333
+}
+
+.prose :where(h2 strong):not(:where([class~="not-prose"] *)) {
+	font-weight: 800
+}
+
+.prose :where(h3):not(:where([class~="not-prose"] *)) {
+	color: inherit;
+	font-weight: 600;
+	font-size: 1.25em;
+	margin-top: 1.6em;
+	margin-bottom: .6em;
+	line-height: 1.6
+}
+
+.prose :where(h3 strong):not(:where([class~="not-prose"] *)) {
+	font-weight: 700
+}
+
+.prose :where(h4):not(:where([class~="not-prose"] *)) {
+	color: inherit;
+	font-weight: 600;
+	margin-top: 1.5em;
+	margin-bottom: .5em;
+	line-height: 1.5
+}
+
+.prose :where(h4 strong):not(:where([class~="not-prose"] *)) {
+	font-weight: 700
+}
+
+.prose :where(figure > *):not(:where([class~="not-prose"] *)) {
+	margin-top: 0;
+	margin-bottom: 0
+}
+
+.prose :where(figcaption):not(:where([class~="not-prose"] *)) {
+	color: var(--tw-prose-captions);
+	font-size: .875em;
+	line-height: 1.4285714;
+	margin-top: .8571429em
+}
+
+.prose :where(code):not(:where([class~="not-prose"] *)) {
+	color: #3b82f6;
+	font-weight: 400;
+	font-size: .875em;
+	background-color: #eff6ff;
+	border-radius: .25rem;
+	padding: .25em .5rem
+}
+
+.prose :where(code):not(:where([class~="not-prose"] *)):before {
+	content: ""
+}
+
+.prose :where(code):not(:where([class~="not-prose"] *)):after {
+	content: ""
+}
+
+.prose :where(a code):not(:where([class~="not-prose"] *)) {
+	color: var(--tw-prose-links)
+}
+
+.prose :where(pre):not(:where([class~="not-prose"] *)) {
+	color: var(--tw-prose-pre-code);
+	background-color: var(--tw-prose-pre-bg);
+	overflow-x: auto;
+	font-weight: 400;
+	font-size: .875em;
+	line-height: 1.7142857;
+	margin-top: 1.7142857em;
+	margin-bottom: 1.7142857em;
+	border-radius: .375rem;
+	padding: .8571429em 1.1428571em;
+	max-width: calc(100vw - 1rem)
+}
+
+.prose :where(pre code):not(:where([class~="not-prose"] *)) {
+	background-color: transparent;
+	border-width: 0;
+	border-radius: 0;
+	padding: 0;
+	font-weight: inherit;
+	text-wrap: wrap;
+	color: inherit;
+	font-size: inherit;
+	font-family: inherit;
+	line-height: inherit
+}
+
+.prose :where(pre code):not(:where([class~="not-prose"] *)):before {
+	content: none
+}
+
+.prose :where(pre code):not(:where([class~="not-prose"] *)):after {
+	content: none
+}
+
+.prose :where(table):not(:where([class~="not-prose"] *)) {
+	width: 100%;
+	table-layout: auto;
+	text-align: left;
+	margin-top: 2em;
+	margin-bottom: 2em;
+	font-size: .875em;
+	line-height: 1.7142857
+}
+
+.prose :where(thead):not(:where([class~="not-prose"] *)) {
+	border-bottom-width: 1px;
+	border-bottom-color: var(--tw-prose-th-borders)
+}
+
+.prose :where(thead th):not(:where([class~="not-prose"] *)) {
+	color: var(--tw-prose-headings);
+	font-weight: 600;
+	vertical-align: bottom;
+	padding-right: .5714286em;
+	padding-bottom: .5714286em;
+	padding-left: .5714286em
+}
+
+.prose :where(tbody tr):not(:where([class~="not-prose"] *)) {
+	border-bottom-width: 1px;
+	border-bottom-color: var(--tw-prose-td-borders)
+}
+
+.prose :where(tbody tr:last-child):not(:where([class~="not-prose"] *)) {
+	border-bottom-width: 0
+}
+
+.prose :where(tbody td):not(:where([class~="not-prose"] *)) {
+	vertical-align: baseline;
+	padding: .5714286em
+}
+
+.prose {
+	--tw-prose-body: #374151;
+	--tw-prose-headings: #111827;
+	--tw-prose-lead: #4b5563;
+	--tw-prose-links: #111827;
+	--tw-prose-bold: #111827;
+	--tw-prose-counters: #6b7280;
+	--tw-prose-bullets: #d1d5db;
+	--tw-prose-hr: #e5e7eb;
+	--tw-prose-quotes: #111827;
+	--tw-prose-quote-borders: #e5e7eb;
+	--tw-prose-captions: #6b7280;
+	--tw-prose-code: #111827;
+	--tw-prose-pre-code: #e5e7eb;
+	--tw-prose-pre-bg: #1f2937;
+	--tw-prose-th-borders: #d1d5db;
+	--tw-prose-td-borders: #e5e7eb;
+	--tw-prose-invert-body: #d1d5db;
+	--tw-prose-invert-headings: #fff;
+	--tw-prose-invert-lead: #9ca3af;
+	--tw-prose-invert-links: #fff;
+	--tw-prose-invert-bold: #fff;
+	--tw-prose-invert-counters: #9ca3af;
+	--tw-prose-invert-bullets: #4b5563;
+	--tw-prose-invert-hr: #374151;
+	--tw-prose-invert-quotes: #f3f4f6;
+	--tw-prose-invert-quote-borders: #374151;
+	--tw-prose-invert-captions: #9ca3af;
+	--tw-prose-invert-code: #fff;
+	--tw-prose-invert-pre-code: #d1d5db;
+	--tw-prose-invert-pre-bg: rgb(0 0 0 / 50%);
+	--tw-prose-invert-th-borders: #4b5563;
+	--tw-prose-invert-td-borders: #374151;
+	font-size: 1rem;
+	line-height: 1.75
+}
+
+.prose :where(p):not(:where([class~="not-prose"] *)) {
+	margin-top: 1.25em;
+	margin-bottom: 1.25em
+}
 
 .prose :where(img):not(:where([class~="not-prose"] *)) {
-    max-width: 100%;
-}
-.prose :where(pre):not(:where([class~="not-prose"] *)) {
-    background-color: var(--tw-prose-pre-bg) !important;
-    min-width: fit-content;
-}
-.prose :where(code):not(:where([class~="not-prose"] *))::before, .prose :where(code):not(:where([class~="not-prose"] *))::after {
-    content: ""
-}
-.prose :where(a):not(:where([class~="not-prose"] *)) {
-    color: inherit;
-    font-weight: 500;
-    text-decoration: underline;
-}
-.prose :where(a):not(:where([class~="not-prose"] *)):hover {
-    opacity: .8;
-    color: #4b5563;
-}
-.prose :where(blockquote):not(:where([class~="not-prose"] *)) {
-    border-left-style: solid;
+	margin-top: 2em;
+	margin-bottom: 2em
 }
 
-.dark :not(:where([class~="not-prose"] *)), .dark .prose :where(td):not(:where([class~="not-prose"] *)) {
-    color: rgb(209 213 219); /*text-gray-300*/
+.prose :where(video):not(:where([class~="not-prose"] *)) {
+	margin-top: 2em;
+	margin-bottom: 2em
 }
-.dark .prose :where(h1,h2,h3,h4,h5,h6,th):not(:where([class~="not-prose"] *)) {
-    color: rgb(243 244 246); /*text-gray-100*/
+
+.prose :where(figure):not(:where([class~="not-prose"] *)) {
+	margin-top: 2em;
+	margin-bottom: 2em
 }
+
+.prose :where(h2 code):not(:where([class~="not-prose"] *)) {
+	font-size: .875em
+}
+
+.prose :where(h3 code):not(:where([class~="not-prose"] *)) {
+	font-size: .9em
+}
+
+.prose :where(li):not(:where([class~="not-prose"] *)) {
+	margin-top: .5em;
+	margin-bottom: .5em
+}
+
+.prose :where(ol > li):not(:where([class~="not-prose"] *)) {
+	padding-left: .375em
+}
+
+.prose :where(ul > li):not(:where([class~="not-prose"] *)) {
+	padding-left: .375em
+}
+
+.prose>:where(ul > li p):not(:where([class~="not-prose"] *)) {
+	margin-top: .75em;
+	margin-bottom: .75em
+}
+
+.prose>:where(ul > li > *:first-child):not(:where([class~="not-prose"] *)) {
+	margin-top: 1.25em
+}
+
+.prose>:where(ul > li > *:last-child):not(:where([class~="not-prose"] *)) {
+	margin-bottom: 1.25em
+}
+
+.prose>:where(ol > li > *:first-child):not(:where([class~="not-prose"] *)) {
+	margin-top: 1.25em
+}
+
+.prose>:where(ol > li > *:last-child):not(:where([class~="not-prose"] *)) {
+	margin-bottom: 1.25em
+}
+
+.prose :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"] *)) {
+	margin-top: .75em;
+	margin-bottom: .75em
+}
+
+.prose :where(hr + *):not(:where([class~="not-prose"] *)) {
+	margin-top: 0
+}
+
+.prose :where(h2 + *):not(:where([class~="not-prose"] *)) {
+	margin-top: 0
+}
+
+.prose :where(h3 + *):not(:where([class~="not-prose"] *)) {
+	margin-top: 0
+}
+
+.prose :where(h4 + *):not(:where([class~="not-prose"] *)) {
+	margin-top: 0
+}
+
+.prose :where(thead th:first-child):not(:where([class~="not-prose"] *)) {
+	padding-left: 0
+}
+
+.prose :where(thead th:last-child):not(:where([class~="not-prose"] *)) {
+	padding-right: 0
+}
+
+.prose :where(tbody td:first-child):not(:where([class~="not-prose"] *)) {
+	padding-left: 0
+}
+
+.prose :where(tbody td:last-child):not(:where([class~="not-prose"] *)) {
+	padding-right: 0
+}
+
+.prose>:where(:first-child):not(:where([class~="not-prose"] *)) {
+	margin-top: 0
+}
+
+.prose>:where(:last-child):not(:where([class~="not-prose"] *)) {
+	margin-bottom: 0
+}
+
+.prose :where(b):not(:where([class~="not-prose"] *)) {
+	color: inherit
+}
+
+.prose :where(em):not(:where([class~="not-prose"] *)) {
+	color: inherit
+}
+
+.prose :where(img):not(:where([class~="not-prose"] *)) {
+	max-width: 100%;
+}
+
+.prose :where(pre):not(:where([class~="not-prose"] *)) {
+	background-color: var(--tw-prose-pre-bg) !important;
+	min-width: fit-content;
+}
+
+.prose :where(code):not(:where([class~="not-prose"] *))::before,
+.prose :where(code):not(:where([class~="not-prose"] *))::after {
+	content: "";
+}
+
+.prose :where(a):not(:where([class~="not-prose"] *)) {
+	color: inherit;
+	font-weight: 500;
+	text-decoration: underline;
+}
+
+.prose :where(a):not(:where([class~="not-prose"] *)):hover {
+	opacity: .8;
+	color: #4b5563;
+}
+
+.prose :where(blockquote):not(:where([class~="not-prose"] *)) {
+	border-left-style: solid;
+}
+
+.dark :not(:where([class~="not-prose"] *)),
+.dark .prose :where(td):not(:where([class~="not-prose"] *)) {
+	color: rgb(209 213 219);
+	/*text-gray-300*/
+}
+
+.dark .prose :where(h1, h2, h3, h4, h5, h6, th):not(:where([class~="not-prose"] *)) {
+	color: rgb(243 244 246);
+	/*text-gray-100*/
+}
+
 .dark .prose :where(code):not(:where([class~="not-prose"] *)) {
-    background-color: rgb(30 58 138); /*text-blue-900*/
-    color: rgb(243 244 246); /*text-gray-100*/
+	background-color: rgb(30 58 138);
+	/*text-blue-900*/
+	color: rgb(243 244 246);
+	/*text-gray-100*/
 }
+
 .dark .prose :where(pre code):not(:where([class~="not-prose"] *)) {
-    background-color: unset;
+	background-color: unset;
 }
-.prose :where(pre):not(:where([class~="not-prose"] *)) > code {
-    background-color: transparent;
+
+.prose :where(pre):not(:where([class~="not-prose"] *))>code {
+	background-color: transparent;
 }
 
 /* override typography */
-:root {
-    --content-width: 54rem;
+/*:root {
+	--content-width: 54rem;
 }
 
-.prose { max-width: var(--content-width); }
+.prose {
+	max-width: var(--content-width);
+}
+
 .prose :where(code):not(:where([class~="not-prose"] *)) {
-    width: var(--content-width);
-    max-width: var(--content-width);
-}
+	width: var(--content-width);
+	max-width: var(--content-width);
+}*/
+
 .dark .prose :where(a):not(:where([class~="not-prose"] *)):hover {
-    opacity: .8;
-    color: rgb(165 180 252); /* text-slate-300 */
+	opacity: .8;
+	color: rgb(165 180 252);
+	/* text-slate-300 */
 }
-.not-prose { max-width: unset; }
-.prose-table { max-width: 56rem; width: 56rem; padding-left: 1px; overflow-x: auto; }
-.hide-h2+h2 { display:none }
-.hljs, .prose :where(pre):not(:where([class~="not-prose"] *)) .hljs {
-    color: var(--tw-prose-pre-code) !important;
-    background-color: var(--tw-prose-pre-bg) !important;
+
+.not-prose {
+	max-width: unset;
 }
+
+.prose-table {
+	max-width: 56rem;
+	width: 56rem;
+	padding-left: 1px;
+	overflow-x: auto;
+}
+
+.hide-h2+h2 {
+	display: none
+}
+
+.hljs,
+.prose :where(pre):not(:where([class~="not-prose"] *)) .hljs {
+	color: var(--tw-prose-pre-code) !important;
+	background-color: var(--tw-prose-pre-bg) !important;
+}
+
 @media (min-width: 1024px) {
-    .lg\:prose-xl {
-        font-size: 1.25rem;
-        line-height: 1.8;
-    }
-    .lg\:prose-xl .not-prose {
-        font-size: 1rem;
-        line-height: 1.75;
-    }
-    .lg\:prose-xl :where(h3):not(:where([class~="not-prose"] *)) {
-        font-size: 1.5em;
-        margin-top: 1.6em;
-        margin-bottom: 0.6666667em;
-        line-height: 1.3333333;
-    }
+	.lg\:prose-xl {
+		font-size: 1.25rem;
+		line-height: 1.8;
+	}
+
+	.lg\:prose-xl .not-prose {
+		font-size: 1rem;
+		line-height: 1.75;
+	}
+
+	.lg\:prose-xl :where(h3):not(:where([class~="not-prose"] *)) {
+		font-size: 1.5em;
+		margin-top: 1.6em;
+		margin-bottom: 0.6666667em;
+		line-height: 1.3333333;
+	}
 }
 
 /* custom containers */
-.copy p, .copy p code { color:#fff }
-.sh-copy { max-height: 34px; }
-.copied { display: none}
-.copying .copied { display: block }
-.copying .nocopy { display: none }
+.copy p,
+.copy p code {
+	color: #fff
+}
 
-.cp p, .cp p code { margin:0; padding:0 }
+.sh-copy {
+	max-height: 34px;
+}
 
-.sh-copy code { font-size: 16px }
-.sh-copy p, .sh-copy p code { color: rgb(243 244 246) }
-.sh-copy p::before { content:'$ '; color: rgb(156 163 175) }
-.sh-copy a { color: rgb(243 244 246) }
-.sh-copy a:hover { text-decoration: none }
+.copied {
+	display: none
+}
+
+.copying .copied {
+	display: block
+}
+
+.copying .nocopy {
+	display: none
+}
+
+.cp p,
+.cp p code {
+	margin: 0;
+	padding: 0
+}
+
+.sh-copy code {
+	font-size: 16px
+}
+
+.sh-copy p,
+.sh-copy p code {
+	color: rgb(243 244 246)
+}
+
+.sh-copy p::before {
+	content: '$ ';
+	color: rgb(156 163 175)
+}
+
+.sh-copy a {
+	color: rgb(243 244 246)
+}
+
+.sh-copy a:hover {
+	text-decoration: none
+}
 
 /* Custom Info Containers*/
-.custom-block.tip,.custom-block.info,.custom-block.warning,.custom-block.danger {
-    margin: 1rem 0;
-    border-left: .5rem solid;
-    padding: .1rem 1.5rem;
-    overflow-x: auto;
-}
-.custom-block.tip {
-    background-color: #f3f5f7;
-    border-color: #007bff
-}
-.custom-block.info {
-    background-color: #f3f5f7;
-    border-color: #476582
-}
-.custom-block.warning {
-    border-color: #e7c000;
-    color: #6b5900;
-    background-color: #ffe5644d
-}
-.custom-block.warning .custom-block-title {
-    color: #b29400
-}
-.custom-block.warning a {
-    color: #2c3e50
-}
+.custom-block.tip,
+.custom-block.info,
+.custom-block.warning,
 .custom-block.danger {
-    border-color: #c00;
-    color: #4d0000;
-    background-color: #ffe6e6
+	margin: 1rem 0;
+	border-left: .5rem solid;
+	padding: .1rem 1.5rem;
+	overflow-x: auto;
 }
+
+.custom-block.tip {
+	background-color: #f3f5f7;
+	border-color: #007bff
+}
+
+.custom-block.info {
+	background-color: #f3f5f7;
+	border-color: #476582
+}
+
+.custom-block.warning {
+	border-color: #e7c000;
+	color: #6b5900;
+	background-color: #ffe5644d
+}
+
+.custom-block.warning .custom-block-title {
+	color: #b29400
+}
+
+.custom-block.warning a {
+	color: #2c3e50
+}
+
+.custom-block.danger {
+	border-color: #c00;
+	color: #4d0000;
+	background-color: #ffe6e6
+}
+
 .custom-block.danger .custom-block-title {
-    color: #900
+	color: #900
 }
+
 .custom-block.danger a {
-    color: #2c3e50
+	color: #2c3e50
 }
+
 .dark .custom-block {
-    background: #111827;
+	background: #111827;
 }
+
 .custom-block.details {
-    position: relative;
-    display: block;
-    border-radius: 2px;
-    margin: 1.6em 0;
-    padding: 1.6em;
-    background-color: #eee
+	position: relative;
+	display: block;
+	border-radius: 2px;
+	margin: 1.6em 0;
+	padding: 1.6em;
+	background-color: #eee
 }
+
 .custom-block.details h4 {
-    margin-top: 0
+	margin-top: 0
 }
-.custom-block.details figure:last-child,.custom-block.details p:last-child {
-    margin-bottom: 0;
-    padding-bottom: 0
+
+.custom-block.details figure:last-child,
+.custom-block.details p:last-child {
+	margin-bottom: 0;
+	padding-bottom: 0
 }
+
 .custom-block.details summary {
-    outline: none;
-    cursor: pointer
+	outline: none;
+	cursor: pointer
 }
+
 .custom-block-title {
-    margin-bottom: -.4rem;
-    font-weight: 600;
-    text-transform: uppercase;
+	margin-bottom: -.4rem;
+	font-weight: 600;
+	text-transform: uppercase;
 }
+
 .table tr {
-    border-top: 1px solid #dfe2e5;
-}
-.table-striped thead tr, .table-striped tr:nth-child(2n), .table-bordered tr:nth-child(2n) {
-    background-color: #f6f8fa;
-}
-.dark .table-striped thead tr, .dark .table-striped tr:nth-child(2n), .dark .table-bordered tr:nth-child(2n) {
-    background-color: #111827;
+	border-top: 1px solid #dfe2e5;
 }
 
-.table-striped thead tr th, .table-striped thead tr td {
-    font-weight: 500;
-    color: #6b7280; /*text-gray-500*/
-}
-.dark .table-striped thead tr th, .dark .table-striped thead tr td {
-    color: #f3f4f6;
+.table-striped thead tr,
+.table-striped tr:nth-child(2n),
+.table-bordered tr:nth-child(2n) {
+	background-color: #f6f8fa;
 }
 
-.table th,.table td {
-    border: 1px solid #dfe2e5;
-    padding: .6em 1em
+.dark .table-striped thead tr,
+.dark .table-striped tr:nth-child(2n),
+.dark .table-bordered tr:nth-child(2n) {
+	background-color: #111827;
 }
-.dark .table th,.dark .table td {
-    border: 1px solid #1f2937;
+
+.table-striped thead tr th,
+.table-striped thead tr td {
+	font-weight: 500;
+	color: #6b7280;
+	/*text-gray-500*/
+}
+
+.dark .table-striped thead tr th,
+.dark .table-striped thead tr td {
+	color: #f3f4f6;
+}
+
+.table th,
+.table td {
+	border: 1px solid #dfe2e5;
+	padding: .6em 1em
+}
+
+.dark .table th,
+.dark .table td {
+	border: 1px solid #1f2937;
 }
 
 .youtube {
-    width: 768px;
-    height: 432px;
+	width: 768px;
+	height: 432px;
 }
+
 @media (max-width: 896px) {
-    .youtube {
-        width: 100%;
-        height: auto;
-    }
+	.youtube {
+		width: 100%;
+		height: auto;
+	}
 }
-.prose pre::-webkit-scrollbar, .prose code::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-    background: #2d3748;
+
+.prose pre::-webkit-scrollbar,
+.prose code::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+	background: #2d3748;
 }
-.prose pre::-webkit-scrollbar-thumb, .prose code::-webkit-scrollbar-thumb {
-    background-color: rgb(100 116 139);
+
+.prose pre::-webkit-scrollbar-thumb,
+.prose code::-webkit-scrollbar-thumb {
+	background-color: rgb(100 116 139);
 }
 
 .html-format {
-    max-width: unset;
+	max-width: unset;
 }
 
 .svg-external {
-    color: #007bff;
-    background: url("data:image/svg+xml,%3Csvg width='1.25rem' height='1.25rem' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none'%3E%3Cpath d='M10 6H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4M14 4h6m0 0v6m0-6L10 14' stroke='%23007bff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/g%3E%3C/svg%3E") no-repeat bottom right;
-    padding-right: 1.35rem;
+	color: #007bff;
+	background: url("data:image/svg+xml,%3Csvg width='1.25rem' height='1.25rem' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none'%3E%3Cpath d='M10 6H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4M14 4h6m0 0v6m0-6L10 14' stroke='%23007bff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/g%3E%3C/svg%3E") no-repeat bottom right;
+	padding-right: 1.35rem;
 }
+
 .svg-external:hover {
-    text-decoration: underline;
+	text-decoration: underline;
 }
 
 
 .header-anchor {
-    float: left;
-    margin-left: -.87em;
-    padding-right: .23em;
-    font-weight: 500;
-    user-select: none;
-    opacity: 0;
-    transition: color .25s,opacity .25s;
-    color: rgb(14 165 233);
-    text-decoration: none;
+	float: left;
+	margin-left: -.87em;
+	padding-right: .23em;
+	font-weight: 500;
+	user-select: none;
+	opacity: 0;
+	transition: color .25s, opacity .25s;
+	color: rgb(14 165 233);
+	text-decoration: none;
 }
+
 .header-anchor:before {
-    content: "#"
+	content: "#"
 }
+
 .header-anchor:hover:before {
-    color: rgb(14 165 233);
-    text-decoration: underline;
+	color: rgb(14 165 233);
+	text-decoration: underline;
 }
-h1:hover .header-anchor, h1 .header-anchor:focus, h2:hover .header-anchor, h2 .header-anchor:focus, h3:hover .header-anchor, h3 .header-anchor:focus, h4:hover .header-anchor, h4 .header-anchor:focus {
-    opacity: 1;
+
+h1:hover .header-anchor,
+h1 .header-anchor:focus,
+h2:hover .header-anchor,
+h2 .header-anchor:focus,
+h3:hover .header-anchor,
+h3 .header-anchor:focus,
+h4:hover .header-anchor,
+h4 .header-anchor:focus {
+	opacity: 1;
 }


### PR DESCRIPTION
Removing partial minification from the file; I see no sense in minifying only the first portion of the file (it should either be minified from start to finish or not at all).

Reintroducing the comments around :root{}, .prose{} and .prose :where(code):not(:where([class~="not-prose"] *)){} classes because the lack of comments causes improper rendering of markdown code blocks as HTML on mobile Safari (and also on desktop Firefox/Chrome if the window width is extremely small).  Probably the only one of the three classes that actually needs to be commented to fix the improper rendering of code blocks is the third one (.prose :where(code):not(:where([class~="not-prose"] *)){}) but in my opinion the site renders correctly without any of the three overrides.

Commenting out .prose {max-width: 65ch;} (line #3 in the non-minified file) because this forces a left-of-center alignment of body content and causes the body content to seem arbitrarily less wide than the banner image.