### PR TITLE
Change application URLs to allow remote browsing

### DIFF
--- a/MyApp/Properties/launchSettings.json
+++ b/MyApp/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "https://localhost:5002/",
+      "applicationUrl": "https://0.0.0.0:5002/",
       "sslPort": 0
     }
   },
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5002/"
+      "applicationUrl": "https://0.0.0.0:5002/"
     },
     "MyApp Prerender": {
       "commandName": "Project",
@@ -30,7 +30,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5002/"
+      "applicationUrl": "https://0.0.0.0:5002/"
     }
   }
 }


### PR DESCRIPTION
If I do `dotnet run` or `dotnet build` on my machine and I then want to browse the page from a different device (ex: my iPhone connected to the same wifi network as my laptop) then I need the application URLs to use 0.0.0.0 (essentially wildcard) instead of localhost.