### PR TITLE
Enabling anchor links

### DIFF
--- a/MyApp/Markdown.Pages.cs
+++ b/MyApp/Markdown.Pages.cs
@@ -35,7 +35,7 @@ public class MarkdownPages(ILogger<MarkdownPages> log, IWebHostEnvironment env, 
             .ToList();
         log.LogInformation("Found {Count} pages", files.Count);
 
-        var pipeline = CreatePipeline();
+        var pipeline = CreatePipeline(string.Empty);
 
         foreach (var file in files)
         {


### PR DESCRIPTION
Fixing the header anchor links so that they actually work (instead of just invoking an empty onclick event). This allows both for a user to click on a header text item to scroll the page to that location as well as for the user to right-click on the anchor link and copy it to the clipboard.