### PR TITLE
Enabling anchor links

### DIFF
--- a/MyApp/Markdown.Podcasts.cs
+++ b/MyApp/Markdown.Podcasts.cs
@@ -142,7 +142,7 @@ public class MarkdownPodcasts(ILogger<MarkdownBlog> log, IWebHostEnvironment env
         var content = file.ReadAllText();
 
         var writer = new StringWriter();
-        var doc = CreateMarkdownFile(content, writer, pipeline);
+        var doc = CreateMarkdownFile(string.Empty, content, writer, pipeline);
         if (doc.Title == null)
         {
             log.LogWarning("No frontmatter found for {VirtualPath}, ignoring...", file.VirtualPath);
@@ -177,7 +177,7 @@ public class MarkdownPodcasts(ILogger<MarkdownBlog> log, IWebHostEnvironment env
         var files = VirtualFiles.GetDirectory(fromDirectory).GetAllFiles().ToList();
         log.LogInformation("Found {Count} podcasts", files.Count);
 
-        var pipeline = CreatePipeline();
+        var pipeline = CreatePipeline(string.Empty);
 
         foreach (var file in files)
         {


### PR DESCRIPTION
Fixing the header anchor links so that they actually work (instead of just invoking an empty onclick event). This allows both for a user to click on a header text item to scroll the page to that location as well as for the user to right-click on the anchor link and copy it to the clipboard.