### PR TITLE
Enabling anchor links

### DIFF
--- a/MyApp/Markdown.Videos.cs
+++ b/MyApp/Markdown.Videos.cs
@@ -23,7 +23,7 @@ public class MarkdownVideos(ILogger<MarkdownVideos> log, IWebHostEnvironment env
         var dirs = VirtualFiles.GetDirectory(fromDirectory).GetDirectories().ToList();
         log.LogInformation("Found {Count} video directories", dirs.Count);
 
-        var pipeline = CreatePipeline();
+        var pipeline = CreatePipeline(string.Empty);
 
         foreach (var dir in dirs)
         {


### PR DESCRIPTION
Fixing the header anchor links so that they actually work (instead of just invoking an empty onclick event). This allows both for a user to click on a header text item to scroll the page to that location as well as for the user to right-click on the anchor link and copy it to the clipboard.