### PR TITLE
Enabling anchor links

### DIFF
--- a/MyApp/Markdown.WhatsNew.cs
+++ b/MyApp/Markdown.WhatsNew.cs
@@ -23,7 +23,7 @@ public class MarkdownWhatsNew(ILogger<MarkdownWhatsNew> log, IWebHostEnvironment
         var dirs = VirtualFiles.GetDirectory(fromDirectory).GetDirectories().ToList();
         log.LogInformation("Found {Count} whatsnew directories", dirs.Count);
 
-        var pipeline = CreatePipeline();
+        var pipeline = CreatePipeline(string.Empty);
 
         foreach (var dir in dirs)
         {


### PR DESCRIPTION
Fixing the header anchor links so that they actually work (instead of just invoking an empty onclick event). This allows both for a user to click on a header text item to scroll the page to that location as well as for the user to right-click on the anchor link and copy it to the clipboard.