### PR TITLE
Enabling anchor links

### DIFF
--- a/MyApp/Markdown.Blog.cs
+++ b/MyApp/Markdown.Blog.cs
@@ -120,7 +120,7 @@ public class MarkdownBlog(ILogger<MarkdownBlog> log, IWebHostEnvironment env, IV
         var content = file.ReadAllText();
 
         var writer = new StringWriter();
-        var doc = CreateMarkdownFile(content, writer, pipeline);
+        var doc = CreateMarkdownFile(path, content, writer, pipeline);
         if (doc.Title == null)
         {
             log.LogWarning("No frontmatter found for {VirtualPath}, ignoring...", file.VirtualPath);
@@ -155,7 +155,7 @@ public class MarkdownBlog(ILogger<MarkdownBlog> log, IWebHostEnvironment env, IV
         var files = VirtualFiles.GetDirectory(fromDirectory).GetAllFiles().ToList();
         log.LogInformation("Found {Count} posts", files.Count);
 
-        var pipeline = CreatePipeline();
+        var pipeline = CreatePipeline(string.Empty);
 
         foreach (var file in files)
         {


### PR DESCRIPTION
Fixing the header anchor links so that they actually work (instead of just invoking an empty onclick event). This allows both for a user to click on a header text item to scroll the page to that location as well as for the user to right-click on the anchor link and copy it to the clipboard.