### PR TITLE
Bug fix for small screens

### DIFF
--- a/MyApp/Pages/Posts/Post.cshtml
+++ b/MyApp/Pages/Posts/Post.cshtml
@@ -144,7 +144,7 @@
                     <img src="@image" alt="@doc.Title Background" class="shadow-small">
                 </div>
             </div>
-            <div class="flex max-w-3xl mx-auto justify-between">
+            <div class="flex max-w-7xl mx-auto justify-between" style="width:100%;">
                 <div>
                     <div class="mb-4 flex flex-wrap">
                         @foreach (var tag in doc.Tags)


### PR DESCRIPTION
Extending the width of the "minutes to read" page element and the tags element to ensure that when users browse on small screens (ex: an iPhone) the comments button and tags and "minutes to read" elements don't render all on top of each other.